### PR TITLE
fix(publish): poll for strongswan run completion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,14 +162,26 @@ jobs:
           RUN_ID="${{ steps.runid.outputs.run_id }}"
           REPO="structured-world/strongswan"
           echo "Verifying workflow run $RUN_ID in $REPO..."
-          if ! run_json=$(gh run view "$RUN_ID" -R "$REPO" --json status,conclusion,headBranch,event,workflowName,createdAt,updatedAt); then
-            echo "Error: unable to view run $RUN_ID in $REPO. The run may not exist, or there may be authentication or network connectivity issues." >&2
-            exit 1
-          fi
-          echo "$run_json" | jq -r '. as $r | "Status: \($r.status)\nConclusion: \($r.conclusion // "none")\nBranch: \($r.headBranch)\nEvent: \($r.event)\nWorkflow: \($r.workflowName)\nCreated: \($r.createdAt)\nUpdated: \($r.updatedAt)"'
-          run_status=$(echo "$run_json" | jq -r '.status')
-          run_conclusion=$(echo "$run_json" | jq -r '.conclusion // "none"')
-          run_workflow=$(echo "$run_json" | jq -r '.workflowName // ""')
+          # Poll until run completes — the trigger-repo job in build-packages is part
+          # of the same run, so the run may still be in_progress when publish starts.
+          POLL_INTERVAL=15
+          POLL_TIMEOUT=600
+          POLL_MAX=$((POLL_TIMEOUT / POLL_INTERVAL))
+          for ((attempt=1; attempt<=POLL_MAX; attempt++)); do
+            if ! run_json=$(gh run view "$RUN_ID" -R "$REPO" --json status,conclusion,headBranch,event,workflowName,createdAt,updatedAt); then
+              echo "Error: unable to view run $RUN_ID in $REPO. The run may not exist, or there may be authentication or network connectivity issues." >&2
+              exit 1
+            fi
+            run_status=$(jq -r '.status' <<< "$run_json")
+            run_conclusion=$(jq -r '.conclusion // "none"' <<< "$run_json")
+            run_workflow=$(jq -r '.workflowName // ""' <<< "$run_json")
+            echo "Attempt ${attempt}/${POLL_MAX}: status=$run_status conclusion=$run_conclusion workflow=$run_workflow"
+            if [ "$run_status" = "completed" ]; then
+              break
+            fi
+            sleep "$POLL_INTERVAL"
+          done
+          jq -r '. as $r | "Status: \($r.status)\nConclusion: \($r.conclusion // "none")\nBranch: \($r.headBranch)\nEvent: \($r.event)\nWorkflow: \($r.workflowName)\nCreated: \($r.createdAt)\nUpdated: \($r.updatedAt)"' <<< "$run_json"
           if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
             echo "Error: run $RUN_ID is not completed successfully (status=$run_status, conclusion=$run_conclusion)" >&2
             exit 1


### PR DESCRIPTION
## Summary

- build-packages `trigger-repo` job triggers publish.yml while it's still part of the same run
- publish.yml checks that the strongswan run is `completed`, but it can't be because `trigger-repo` hasn't finished yet
- adds polling loop (15s interval, 10min timeout) to wait for run completion before downloading artifacts

## Context

Discovered while testing the full build → sign → publish chain via `workflow_dispatch` on strongswan sw branch (run 21545318766). All 7 build/sign jobs passed, but publish failed immediately with `status=in_progress`.

## Test plan

- [ ] Merge PR
- [ ] Re-trigger `build-packages.yml` on strongswan sw branch
- [ ] Verify publish.yml polls until run completes and downloads artifacts