### PR TITLE
fix(publish): include run ID in run-name (#6)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Publish Repo
-run-name: Publish Repo (strongswan)
+run-name: "Publish Repo (strongswan ${{ inputs.strongswan_run_id || github.event.client_payload.strongswan_run_id }})"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- `publish.yml` run-name was static `Publish Repo (strongswan)`, but `trigger-repo` in build-packages.yml searches for `Publish Repo (strongswan <run_id>)`
- mismatch caused trigger-repo to never find the publish run → 10min timeout → chain failure
- now includes `strongswan_run_id` in the run-name

Fixes #6