### PR TITLE
fix(publish): add -mindepth 1 to artifact dir validation (#8)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,9 +191,9 @@ jobs:
             find packages -maxdepth 1 -type f -print >&2
             exit 1
           fi
-          if find packages -maxdepth 1 -type d ! -name 'deb-*' ! -name 'rpm-fc*' ! -name 'srpm' | grep -q .; then
+          if find packages -mindepth 1 -maxdepth 1 -type d ! -name 'deb-*' ! -name 'rpm-fc*' ! -name 'srpm' | grep -q .; then
             echo "Error: unexpected artifact directories found in packages/" >&2
-            find packages -maxdepth 1 -type d ! -name 'deb-*' ! -name 'rpm-fc*' ! -name 'srpm' -print >&2
+            find packages -mindepth 1 -maxdepth 1 -type d ! -name 'deb-*' ! -name 'rpm-fc*' ! -name 'srpm' -print >&2
             exit 1
           fi
           ls -la packages


### PR DESCRIPTION
## Summary

- `find packages -maxdepth 1 -type d` returns `packages` itself as first result
- it doesn't match `deb-*`/`rpm-fc*`/`srpm` patterns → false positive "unexpected artifact directories"
- add `-mindepth 1` to skip the root directory

Related to #8