### PR TITLE
fix(publish): remove redundant srpm mv (#8)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,9 +238,8 @@ jobs:
               [ -d "$dir" ] || continue
               find "$dir" -type f -name '*.rpm' -exec mv -n {} packages/rpm/ \;
             done
-            if [ -d packages/srpm ]; then
-              find packages/srpm -type f -name '*.rpm' -exec mv -n {} packages/srpm/ \;
-            fi
+            # srpm artifact downloads directly into packages/srpm/ — no move needed.
+            # deb-*/rpm-fc* need flattening because each matrix job creates a separate artifact.
           fi
           scripts/update-repos.sh
 


### PR DESCRIPTION
## Summary

- `srpm` artifact downloads directly into `packages/srpm/`
- `find packages/srpm ... -exec mv -n {} packages/srpm/` tries to move files into the same directory
- `mv -n` returns exit code 1 on coreutils 9.0+ when skipping (not replacing)
- `set -e` catches it → workflow fails
- `deb-*`/`rpm-fc*` still need flattening (separate per-matrix artifacts)

Related to #8