### PR TITLE
ci(publish): add set -x tracing to diagnose silent failure (#12)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,6 +227,7 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
+          set -x
           chmod +x scripts/update-repos.sh
           if [ -d packages ]; then
             mkdir -p packages/deb packages/rpm packages/srpm
@@ -241,6 +242,9 @@ jobs:
             # srpm artifact downloads directly into packages/srpm/ — no move needed.
             # deb-*/rpm-fc* need flattening because each matrix job creates a separate artifact.
           fi
+          echo "=== Package layout before update-repos.sh ==="
+          find packages -type f | sort || true
+          echo "=== Running update-repos.sh ==="
           scripts/update-repos.sh
 
       - name: Cleanup downloaded packages

--- a/scripts/update-repos.sh
+++ b/scripts/update-repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"


### PR DESCRIPTION
## Summary
- Add `set -x` tracing to inline script and `update-repos.sh` to diagnose why the script exits with code 1 in ~70ms without any output
- Temporary debug commit — will be reverted after identifying the issue

Closes #12