### PR TITLE
ci(publish): merge stderr into stdout for trace visibility (#12)

### DIFF
--- a/scripts/update-repos.sh
+++ b/scripts/update-repos.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
+# DEBUG: merge stderr into stdout so CI captures all trace lines before exit.
+exec 2>&1
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"


### PR DESCRIPTION
## Summary
- `exec 2>&1` ensures set -x trace and DEBUG echoes go through stdout
- CI runner captures stdout line-by-line but stderr pipe buffer may be lost on exit
- Previous runs show trace stopping at `nullglob_state=` with no further output

Relates to #12