### PR TITLE
fix(publish): guard shopt -p against exit code 1 (#12)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -227,7 +227,6 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          set -x
           chmod +x scripts/update-repos.sh
           if [ -d packages ]; then
             mkdir -p packages/deb packages/rpm packages/srpm
@@ -242,9 +241,6 @@ jobs:
             # srpm artifact downloads directly into packages/srpm/ — no move needed.
             # deb-*/rpm-fc* need flattening because each matrix job creates a separate artifact.
           fi
-          echo "=== Package layout before update-repos.sh ==="
-          find packages -type f | sort || true
-          echo "=== Running update-repos.sh ==="
           scripts/update-repos.sh
 
       - name: Cleanup downloaded packages

--- a/scripts/update-repos.sh
+++ b/scripts/update-repos.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
-# DEBUG: merge stderr into stdout so CI captures all trace lines before exit.
-exec 2>&1
+set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -36,7 +34,6 @@ gpg_sign() {
 }
 
 publish_deb() {
-  echo "DEBUG: publish_deb() entered" >&2
   for bin in apt-ftparchive dpkg-deb gpg gzip; do
     if ! command -v "$bin" >/dev/null 2>&1; then
       echo "Error: required command not found: $bin" >&2
@@ -50,20 +47,16 @@ publish_deb() {
   fi
 
   local nullglob_state
-  nullglob_state=$(shopt -p nullglob)
-  echo "DEBUG: nullglob_state=$nullglob_state" >&2
+  # shopt -p returns exit code 1 when the option is off; guard with || true.
+  nullglob_state=$(shopt -p nullglob || true)
   shopt -s nullglob
-  echo "DEBUG: nullglob set" >&2
   trap 'eval "$nullglob_state"' RETURN
-  echo "DEBUG: trap set, expanding $DEB_SRC_DIR/*.deb" >&2
   local debs=("$DEB_SRC_DIR"/*.deb)
-  echo "DEBUG: found ${#debs[@]} debs" >&2
   if [ ${#debs[@]} -eq 0 ]; then
     echo "No DEB packages to publish"
     return 0
   fi
 
-  echo "DEBUG: starting deb loop" >&2
   for deb in "${debs[@]}"; do
     local pkgname first_letter pool_dir
     if ! pkgname=$(dpkg-deb -f "$deb" Package 2>/dev/null); then
@@ -94,7 +87,6 @@ publish_deb() {
     echo "Copied $deb to $pool_dir/"
   done
 
-  echo "DEBUG: deb pool copy done, processing dists" >&2
   local dist_dir dist
   if [ -d deb/dists ]; then
     for dist_dir in deb/dists/*; do
@@ -171,7 +163,6 @@ Description: SW Foundation Package Repository
 EOF_RELEASE
 
       apt-ftparchive release "$dist_dir" >> "$dist_dir/Release"
-      echo "DEBUG: signing Release for $dist_dir" >&2
       gpg_sign --armor --detach-sign -o "$dist_dir/Release.gpg" "$dist_dir/Release"
       if [ ! -s "$dist_dir/Release.gpg" ] || ! gpg --verify "$dist_dir/Release.gpg" "$dist_dir/Release" >/dev/null 2>&1; then
         echo "Error: Failed to create valid GPG signature for $dist_dir/Release (Release.gpg)" >&2
@@ -189,7 +180,6 @@ EOF_RELEASE
 }
 
 publish_rpm() {
-  echo "DEBUG: publish_rpm() entered" >&2
   for bin in createrepo_c gpg rpm rpmsign; do
     if ! command -v "$bin" >/dev/null 2>&1; then
       echo "Error: required command not found: $bin" >&2
@@ -260,7 +250,8 @@ publish_rpm() {
   fi
 
   local nullglob_state
-  nullglob_state=$(shopt -p nullglob)
+  # shopt -p returns exit code 1 when the option is off; guard with || true.
+  nullglob_state=$(shopt -p nullglob || true)
   shopt -s nullglob
   trap 'eval "$nullglob_state"' RETURN
   local rpms=("$RPM_SRC_DIR"/*.rpm)
@@ -352,8 +343,5 @@ publish_rpm() {
   done
 }
 
-echo "DEBUG: calling publish_deb" >&2
 publish_deb
-echo "DEBUG: publish_deb done, calling publish_rpm" >&2
 publish_rpm
-echo "DEBUG: publish_rpm done, all complete" >&2


### PR DESCRIPTION
## Summary
- `shopt -p nullglob` returns exit code 1 when nullglob is off — this kills the script under `set -e`
- Add `|| true` guard to both `publish_deb` and `publish_rpm` in update-repos.sh
- Remove all debug tracing (set -x, exec 2>&1, DEBUG echo statements)

## Root cause
```bash
$ bash -c 'shopt -p nullglob; echo "exit: $?"'
shopt -u nullglob
exit: 1
```
`shopt -p` prints the option state correctly but returns non-zero when the option is **off**. With `set -e`, `nullglob_state=$(shopt -p nullglob)` assigns the value but then bash terminates due to the non-zero exit code.

Closes #12