### PR TITLE
fix(publish): fix RPM filename regex for multi-hyphen package names (#17)

### DIFF
--- a/scripts/update-repos.sh
+++ b/scripts/update-repos.sh
@@ -263,8 +263,8 @@ publish_rpm() {
     local filename fc_ver dest_dir
     filename=$(basename "$rpm")
     # Only numeric Fedora versions are supported in repo layout.
-    # Expected pattern: name-version-release.fcNN.arch.rpm
-    if [[ "$filename" =~ ^[^-]+-[0-9][^-]*-[^-]*\.fc([0-9]+)\.[^.]+\.rpm$ ]]; then
+    # RPM NEVRA: name-version-release.arch.rpm (name may contain hyphens).
+    if [[ "$filename" =~ ^.+-[0-9][^-]*-[^-]*\.fc([0-9]+)\.[^.]+\.rpm$ ]]; then
       fc_ver="${BASH_REMATCH[1]}"
       dest_dir="rpm/fc${fc_ver}"
       mkdir -p "$dest_dir"


### PR DESCRIPTION
## Summary
- RPM NEVRA pattern `^[^-]+` only matches the first segment before a hyphen
- Package names like `strongswan-sw`, `strongswan-dhcp-inform`, `strongswan-pgsql-debuginfo` all fail to match
- Binary RPMs were silently skipped (only SRPMs were published)
- Fix: replace `[^-]+` with `.+` for greedy name matching

## Verification
```bash
# Before (broken)
bash -c '[[ "strongswan-sw-6.0.4.sw.11-1.fc42.x86_64.rpm" =~ ^[^-]+-[0-9][^-]*-[^-]*\.fc([0-9]+)\.[^.]+\.rpm$ ]] && echo MATCH || echo "NO MATCH"'
# -> NO MATCH

# After (fixed)
bash -c '[[ "strongswan-sw-6.0.4.sw.11-1.fc42.x86_64.rpm" =~ ^.+-[0-9][^-]*-[^-]*\.fc([0-9]+)\.[^.]+\.rpm$ ]] && echo "MATCH fc${BASH_REMATCH[1]}" || echo "NO MATCH"'
# -> MATCH fc42
```

Closes #17