### PR TITLE
fix(publish): align coordinode error message and manifest format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -288,7 +288,7 @@ jobs:
           REPO="structured-world/coordinode"
           echo "Verifying workflow run $RUN_ID in $REPO..."
           if ! run_json=$(gh run view "$RUN_ID" -R "$REPO" --json status,headBranch,event,workflowName,createdAt,updatedAt); then
-            echo "Error: unable to view run $RUN_ID in $REPO." >&2
+            echo "Error: unable to view run $RUN_ID in $REPO. Verify that the run exists, that GH_TOKEN has permission to read workflow runs/artifacts in $REPO, and that there is no GitHub API or network issue." >&2
             exit 1
           fi
           jq -r '. as $r | "Status: \($r.status)\nBranch: \($r.headBranch)\nEvent: \($r.event)\nWorkflow: \($r.workflowName)\nCreated: \($r.createdAt)\nUpdated: \($r.updatedAt)"' <<< "$run_json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
           REPO="structured-world/strongswan"
           echo "Verifying workflow run $RUN_ID in $REPO..."
           if ! run_json=$(gh run view "$RUN_ID" -R "$REPO" --json status,headBranch,event,workflowName,createdAt,updatedAt); then
-            echo "Error: unable to view run $RUN_ID in $REPO. The run may not exist, or there may be authentication or network connectivity issues." >&2
+            echo "Error: unable to view run $RUN_ID in $REPO. Verify that the run exists, that GH_TOKEN has permission to read workflow runs/artifacts in $REPO, and that there is no GitHub API or network issue." >&2
             exit 1
           fi
           jq -r '. as $r | "Status: \($r.status)\nBranch: \($r.headBranch)\nEvent: \($r.event)\nWorkflow: \($r.workflowName)\nCreated: \($r.createdAt)\nUpdated: \($r.updatedAt)"' <<< "$run_json"

--- a/manifests/coordinode/manifest.json
+++ b/manifests/coordinode/manifest.json
@@ -14,8 +14,7 @@
       "summary": "Unified database for AI-native applications",
       "category": "main",
       "icon": "database",
-      "requires": null,
-      "docs": null
+      "requires": null
     }
   ],
   "platforms": {


### PR DESCRIPTION
## Summary
- Expand both run lookup error messages (strongswan and coordinode) with permission/network hints — both steps now use identical, actionable wording
- Remove explicit `docs: null` from coordinode manifest package entry; omitting the key matches the strongswan manifest convention

## Changes
- `.github/workflows/publish.yml` line 179: strongswan error message now matches coordinode
- `.github/workflows/publish.yml` line 291: coordinode error message with permission/network hints
- `manifests/coordinode/manifest.json`: removed `"docs": null` from package entry

Closes #23